### PR TITLE
Include ImportLibs and other missing attributes

### DIFF
--- a/oledump/Program.cs
+++ b/oledump/Program.cs
@@ -28,7 +28,6 @@ namespace Org.Benf.OleDump
                 System.Console.WriteLine("OleDump:\r\n");
                 System.Console.Error.WriteLine("Error : " + e.Message);
             }
-            System.Console.ReadKey();
         }
     }
 }

--- a/oledump/Program.cs
+++ b/oledump/Program.cs
@@ -28,6 +28,7 @@ namespace Org.Benf.OleDump
                 System.Console.WriteLine("OleDump:\r\n");
                 System.Console.Error.WriteLine("Error : " + e.Message);
             }
+            System.Console.ReadKey();
         }
     }
 }

--- a/olewoo_cs/Typelib/OWCoClass.cs
+++ b/olewoo_cs/Typelib/OWCoClass.cs
@@ -45,8 +45,7 @@ namespace Org.Benf.OleWoo.Typelib
         {
             ih.AppendLine("[");
             var lprops = new List<string> {$"uuid({_ta.guid})"};
-            //OWCustData.GetCustData(_ti, ref lprops);
-            CustomDatas
+            OWCustData.GetCustData(_ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);
             for (var i = 0; i < lprops.Count; ++i)

--- a/olewoo_cs/Typelib/OWCoClass.cs
+++ b/olewoo_cs/Typelib/OWCoClass.cs
@@ -45,6 +45,8 @@ namespace Org.Benf.OleWoo.Typelib
         {
             ih.AppendLine("[");
             var lprops = new List<string> {$"uuid({_ta.guid})"};
+            var ta = new TypeAttr(_ti);
+            lprops.Add($"version({ta.wMajorVerNum}.{ta.wMinorVerNum})");
             OWCustData.GetCustData(_ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);

--- a/olewoo_cs/Typelib/OWCoClass.cs
+++ b/olewoo_cs/Typelib/OWCoClass.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using olewoo_interop;
+using IMPLTYPEFLAGS = System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS;
 
 namespace Org.Benf.OleWoo.Typelib
 {
@@ -37,10 +40,12 @@ namespace Org.Benf.OleWoo.Typelib
             }
             return res;
         }
+
         public override void BuildIDLInto(IDLFormatter ih)
         {
             ih.AppendLine("[");
             var lprops = new List<string> {$"uuid({_ta.guid})"};
+            OWCustData.GetCustData(_ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);
             for (var i = 0; i < lprops.Count; ++i)

--- a/olewoo_cs/Typelib/OWCoClass.cs
+++ b/olewoo_cs/Typelib/OWCoClass.cs
@@ -45,7 +45,8 @@ namespace Org.Benf.OleWoo.Typelib
         {
             ih.AppendLine("[");
             var lprops = new List<string> {$"uuid({_ta.guid})"};
-            OWCustData.GetCustData(_ti, ref lprops);
+            //OWCustData.GetCustData(_ti, ref lprops);
+            CustomDatas
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);
             for (var i = 0; i < lprops.Count; ++i)

--- a/olewoo_cs/Typelib/OWCustData.cs
+++ b/olewoo_cs/Typelib/OWCustData.cs
@@ -43,5 +43,27 @@ namespace Org.Benf.OleWoo.Typelib
             NativeMethods.ClearCustData(ptr);
             Marshal.FreeHGlobal(ptr);
         }
+
+        public static void GetAllFuncCustData(int index, ITypeInfo ti, ref List<string> lprops)
+        {
+            if (!(ti is ITypeInfo2 t2))
+            {
+                return;
+            }
+
+            var custdata = new CUSTDATA();
+            var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(custdata));
+            t2.GetAllFuncCustData(index, ptr);
+            custdata = Marshal.PtrToStructure<CUSTDATA>(ptr);
+            for (var x = 0; x < custdata.cCustData; x++)
+            {
+                var item = new CUSTDATAITEM(); // just to size it for next line
+                var itemPtr = custdata.prgCustData + (x * Marshal.SizeOf(item));
+                item = Marshal.PtrToStructure<CUSTDATAITEM>(itemPtr);
+                lprops.Add($"custom({item.guid}, {ITypeInfoXtra.QuoteString(item.varValue)})");
+            }
+            NativeMethods.ClearCustData(ptr);
+            Marshal.FreeHGlobal(ptr);
+        }
     }
 }

--- a/olewoo_cs/Typelib/OWCustData.cs
+++ b/olewoo_cs/Typelib/OWCustData.cs
@@ -38,7 +38,7 @@ namespace Org.Benf.OleWoo.Typelib
                 var item = new CUSTDATAITEM(); // just to size it for next line
                 var itemPtr = custdata.prgCustData + (x * Marshal.SizeOf(item));
                 item = Marshal.PtrToStructure<CUSTDATAITEM>(itemPtr);
-                lprops.Add($"custom({item.guid}, \"{item.varValue}\")");
+                lprops.Add($"custom({item.guid}, {ITypeInfoXtra.QuoteString(item.varValue)})");
             }
             NativeMethods.ClearCustData(ptr);
             Marshal.FreeHGlobal(ptr);

--- a/olewoo_cs/Typelib/OWCustData.cs
+++ b/olewoo_cs/Typelib/OWCustData.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Org.Benf.OleWoo.Typelib
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CUSTDATAITEM
+    {
+        public Guid guid;
+        [MarshalAs(UnmanagedType.Struct)]
+        public object varValue;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CUSTDATA
+    {
+        public int cCustData;
+        public IntPtr prgCustData;
+    }
+
+    public static class OWCustData
+    {
+        public static void GetCustData(ITypeInfo ti, ref List<string> lprops)
+        {
+            if (!(ti is ITypeInfo2 t2))
+            {
+                return;
+            }
+
+            var custdata = new CUSTDATA();
+            var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(custdata));
+            t2.GetAllCustData(ptr);
+            custdata = Marshal.PtrToStructure<CUSTDATA>(ptr);
+            for (var x = 0; x < custdata.cCustData; x++)
+            {
+                var item = new CUSTDATAITEM(); // just to size it for next line
+                var itemPtr = custdata.prgCustData + (x * Marshal.SizeOf(item));
+                item = Marshal.PtrToStructure<CUSTDATAITEM>(itemPtr);
+                lprops.Add($"custom({item.guid}, \"{item.varValue}\")");
+            }
+            NativeMethods.ClearCustData(ptr);
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+}

--- a/olewoo_cs/Typelib/OWDispInterface.cs
+++ b/olewoo_cs/Typelib/OWDispInterface.cs
@@ -87,6 +87,7 @@ namespace Org.Benf.OleWoo.Typelib
         {
             ih.AppendLine("[");
             var lprops = new List<string> {"uuid(" + _ta.guid + ")"};
+            OWCustData.GetCustData(_ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);
             if (0 != (_ta.wTypeFlags & TypeAttr.TypeFlags.TYPEFLAG_FHIDDEN)) lprops.Add("hidden");

--- a/olewoo_cs/Typelib/OWDispInterface.cs
+++ b/olewoo_cs/Typelib/OWDispInterface.cs
@@ -87,6 +87,8 @@ namespace Org.Benf.OleWoo.Typelib
         {
             ih.AppendLine("[");
             var lprops = new List<string> {"uuid(" + _ta.guid + ")"};
+            var ta = new TypeAttr(_ti);
+            lprops.Add($"version({ta.wMajorVerNum}.{ta.wMinorVerNum})");
             OWCustData.GetCustData(_ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);

--- a/olewoo_cs/Typelib/OWInterface.cs
+++ b/olewoo_cs/Typelib/OWInterface.cs
@@ -53,6 +53,7 @@ namespace Org.Benf.OleWoo.Typelib
         {
             ih.AppendLine("[");
             var lprops = new List<string> {$"uuid({_ta.guid})"};
+            OWCustData.GetCustData(_ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);
             if (0 != (_ta.wTypeFlags & TypeAttr.TypeFlags.TYPEFLAG_FHIDDEN)) lprops.Add("hidden");

--- a/olewoo_cs/Typelib/OWInterface.cs
+++ b/olewoo_cs/Typelib/OWInterface.cs
@@ -53,6 +53,8 @@ namespace Org.Benf.OleWoo.Typelib
         {
             ih.AppendLine("[");
             var lprops = new List<string> {$"uuid({_ta.guid})"};
+            var ta = new TypeAttr(_ti);
+            lprops.Add($"version({ta.wMajorVerNum}.{ta.wMinorVerNum})");
             OWCustData.GetCustData(_ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(-1, out var context);
             AddHelpStringAndContext(lprops, help, context);

--- a/olewoo_cs/Typelib/OWMethod.cs
+++ b/olewoo_cs/Typelib/OWMethod.cs
@@ -72,6 +72,7 @@ namespace Org.Benf.OleWoo.Typelib
                     lprops.Add("propputref");
                     break;
             }
+            OWCustData.GetAllFuncCustData(_fd.memid -1, _ti, ref lprops);
             var help = _ti.GetHelpDocumentationById(_fd.memid, out var context);
             if (0 != (_fd.wFuncFlags & FuncDesc.FuncFlags.FUNCFLAG_FRESTRICTED)) lprops.Add("restricted");
             if (0 != (_fd.wFuncFlags & FuncDesc.FuncFlags.FUNCFLAG_FHIDDEN)) lprops.Add("hidden");

--- a/olewoo_cs/Typelib/OWTypeLib.cs
+++ b/olewoo_cs/Typelib/OWTypeLib.cs
@@ -87,7 +87,17 @@ namespace Org.Benf.OleWoo.Typelib
             ih.AppendLine("{");
             using (new IDLHelperTab(ih))
             {
-                // How do I know I'm importing stdole2??!
+                var lmd = new TypeLibMetadata();
+                var l = lmd.GetDependentLibraries(_tlib);
+                foreach (var dl in l)
+                {
+                    var attr = new TypeLibAttr(dl);
+
+                    ih.AppendLine($"// Tlib : {dl.GetName()} : {{{attr.guid}}}");
+                    ih.AppendLine($"importlib(\"{dl.GetName()}\");");
+                }
+                ih.AppendLine(string.Empty);
+
                 // Forward declare all interfaces.
                 ih.AppendLine("// Forward declare all types defined in this typelib");
                 /* 
@@ -101,7 +111,7 @@ namespace Org.Benf.OleWoo.Typelib
                         return x;
                     });
                 Children.FindAll(x => ((x as OWInterface) != null || (x as OWDispInterface) != null)).ForEach(
-                    x => ih.AppendLine(x.Name)
+                    x => ih.AppendLine(string.Concat(x.Name, ";"))
                         );
                 Children.FindAll(x => x.DisplayAtTLBLevel(interfaceNames)).ForEach(
                    x => { x.BuildIDLInto(ih); ih.AppendLine(""); }

--- a/olewoo_cs/Win32.cs
+++ b/olewoo_cs/Win32.cs
@@ -12,6 +12,9 @@ namespace Org.Benf.OleWoo
         [DllImport("oleaut32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
         public static extern int LoadTypeLib(string fileName, out ITypeLib typeLib);
 
+        [DllImport("oleaut32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static extern void ClearCustData(IntPtr pCustData);
+
         public static void SetTabs(this System.Windows.Forms.TextBox box, int nSpaces)
         {
             //EM_SETTABSTOPS - http://msdn.microsoft.com/en-us/library/bb761663%28VS.85%29.aspx

--- a/olewoo_cs/olewoo_cs.csproj
+++ b/olewoo_cs/olewoo_cs.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Typelib\ITypeInfoXtra.cs" />
     <Compile Include="Typelib\OWChildrenIndirect.cs" />
     <Compile Include="Typelib\OWCoClass.cs" />
+    <Compile Include="Typelib\OWCustData.cs" />
     <Compile Include="Typelib\OWDispInterface.cs" />
     <Compile Include="Typelib\OWDispInterfaceInheritedInterfaces.cs" />
     <Compile Include="Typelib\OWDispProperty.cs" />

--- a/olewoo_interop/olewoo_interop.cpp
+++ b/olewoo_interop/olewoo_interop.cpp
@@ -6,7 +6,6 @@
  *
  */
 #include "stdafx.h"
-
 #include "olewoo_interop.h"
 
 using namespace olewoo_interop;

--- a/olewoo_interop/olewoo_interop.h
+++ b/olewoo_interop/olewoo_interop.h
@@ -149,8 +149,20 @@ namespace olewoo_interop {
 				return MkSystemGuid(_plibAttr->guid);
 			}
 		}
-//    LCID lcid;
-//    SYSKIND syskind;
+		property int lcid
+		{
+			int get()
+			{
+				return _plibAttr->lcid;
+			}
+		}
+		property int syskind
+		{
+			int get()
+			{
+				return _plibAttr->syskind;
+			}
+		}
 		property int wMajorVerNum
 		{
 			int get()

--- a/olewoo_interop/olewoo_interop.h
+++ b/olewoo_interop/olewoo_interop.h
@@ -15,8 +15,61 @@ namespace olewoo_interop {
 		virtual void AddLink(System::String ^ s, System::String ^ s2) = 0;
 	};
 
+	public ref class CustomTypeLibData
+	{
+		System::String^ _libName;
+		System::Guid^ _libGuid;
+		DWORD _majorVersion;
+		DWORD _minorVersion;
+	public:
+		property System::String^ LibName
+		{
+			System::String^ get()
+			{
+				return _libName;
+			}
+			void set(System::String^ value)
+			{
+				_libName = value;
+			}
+		}
+		property System::Guid^ LibGuid
+		{
+			System::Guid^ get()
+			{
+				return _libGuid;
+			}
+			void set(System::Guid^ value)
+			{
+				_libGuid = value;
+			}
+		}
+		property DWORD MajorVersion
+		{
+			DWORD get()
+			{
+				return _majorVersion;
+			}
+			void set(DWORD value)
+			{
+				_majorVersion = value;
+			}
+		}
+		property DWORD MinorVersion
+		{
+			DWORD get()
+			{
+				return _minorVersion;
+			}
+			void set(DWORD value)
+			{
+				_minorVersion = value;
+			}
+		}
+	};
+
 	System::Guid MkSystemGuid(GUID & graw);
-	void stringifyTypeDesc(TYPEDESC* typeDesc, ITypeInfo* pTypeInfo, IDLFormatter_iop ^ ift);
+	void stringifyTypeDesc(TYPEDESC* typeDesc, ITypeInfo* pTypeInfo, IDLFormatter_iop ^ ift, CustomTypeLibData ^ custLibData);
 
 	public ref class CustomData
 	{
@@ -147,12 +200,12 @@ namespace olewoo_interop {
 		{
 			m_ptd = &td;
 		}
-		void ComTypeNameAsString(System::Runtime::InteropServices::ComTypes::ITypeInfo ^ ti, IDLFormatter_iop ^ ift)
+		void ComTypeNameAsString(System::Runtime::InteropServices::ComTypes::ITypeInfo ^ ti, IDLFormatter_iop ^ ift, CustomTypeLibData ^ custLibData)
 		{
 			CComVariant tmp;
 			System::Runtime::InteropServices::Marshal::GetNativeVariantForObject(ti, System::IntPtr(&tmp));
 			CComQIPtr<ITypeInfo> titmp = tmp.punkVal;
-			stringifyTypeDesc(m_ptd, titmp, ift);
+			stringifyTypeDesc(m_ptd, titmp, ift, custLibData);
 		}
 		property int hreftype
 		{

--- a/olewoo_interop/olewoo_interop.vcxproj
+++ b/olewoo_interop/olewoo_interop.vcxproj
@@ -105,12 +105,14 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="typelibdependencies.cpp" />
     <ClCompile Include="typestring.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="olewoo_interop.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="Stdafx.h" />
+    <ClInclude Include="typelibdependencies.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="app.ico" />

--- a/olewoo_interop/olewoo_interop.vcxproj.filters
+++ b/olewoo_interop/olewoo_interop.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="typestring.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="typelibdependencies.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="olewoo_interop.h">
@@ -36,6 +39,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="typelibdependencies.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/olewoo_interop/typelibdependencies.cpp
+++ b/olewoo_interop/typelibdependencies.cpp
@@ -1,0 +1,191 @@
+#include "Stdafx.h"
+#include "typelibdependencies.h"
+
+std::unordered_set<ITypeLibPtr> GetDependencies(ITypeLib* pTypeLib)
+{
+	// get dependencies
+	std::unordered_set<ITypeLibPtr> output;
+	std::unordered_set<ITypeInfoPtr> history;
+	GetDependenciesHelper(pTypeLib, &history, &output);
+	return output;
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	// iterate over type infos
+	auto typeInfoCount = pTypeLib->GetTypeInfoCount();
+	for (UINT typeInfoIndex = 0; typeInfoIndex < typeInfoCount; ++typeInfoIndex)
+	{
+		// get type info
+		ITypeInfoPtr pTypeInfo;
+		_com_util::CheckError(pTypeLib->GetTypeInfo(typeInfoIndex, &pTypeInfo));
+
+		// get dependencies for type info
+		GetDependenciesHelper(pTypeLib, pTypeInfo, pHistory, pOutput);
+	}
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	// short-circuit if we've already processed this type info
+	if (!pHistory->insert(pTypeInfo).second)
+		return;
+
+	// get type attributes
+	TYPEATTR* typeAttributes;
+	_com_util::CheckError(pTypeInfo->GetTypeAttr(&typeAttributes));
+	try
+	{
+		// special handling for aliases
+		if (typeAttributes->typekind == TKIND_ALIAS)
+		{
+			// get dependencies of the alias
+			GetDependenciesHelper(pTypeLib, pTypeInfo, typeAttributes->tdescAlias, pHistory, pOutput);
+		}
+		else
+		{
+			// iterate over implemented types
+			auto implementedTypeCount = typeAttributes->cImplTypes;
+			for (WORD implementedTypeIndex = 0; implementedTypeIndex < implementedTypeCount; ++implementedTypeIndex)
+			{
+				// get type reference
+				HREFTYPE hRefType;
+				_com_util::CheckError(pTypeInfo->GetRefTypeOfImplType(implementedTypeIndex, &hRefType));
+
+				// get dependencies of the implementation
+				GetDependenciesHelper(pTypeLib, pTypeInfo, hRefType, pHistory, pOutput);
+			}
+
+			// iterate over functions
+			auto functionCount = typeAttributes->cFuncs;
+			for (WORD functionIndex = 0; functionIndex < functionCount; ++functionIndex)
+			{
+				// get function description
+				FUNCDESC* functionDescription;
+				_com_util::CheckError(pTypeInfo->GetFuncDesc(functionIndex, &functionDescription));
+				try
+				{
+					// get dependencies of the function declaration
+					GetDependenciesHelper(pTypeLib, pTypeInfo, *functionDescription, pHistory, pOutput);
+				}
+				catch (...)
+				{
+					// release function description
+					pTypeInfo->ReleaseFuncDesc(functionDescription);
+					throw;
+				}
+
+				// release function description
+				pTypeInfo->ReleaseFuncDesc(functionDescription);
+			}
+
+			// iterate over variables
+			auto variableCount = typeAttributes->cVars;
+			for (WORD variableIndex = 0; variableIndex < variableCount; ++variableIndex)
+			{
+				// get variable description
+				VARDESC* variableDescription;
+				_com_util::CheckError(pTypeInfo->GetVarDesc(variableIndex, &variableDescription));
+				try
+				{
+					// get dependencies of the variable declaration
+					GetDependenciesHelper(pTypeLib, pTypeInfo, *variableDescription, pHistory, pOutput);
+				}
+				catch (...)
+				{
+					// release variable description
+					pTypeInfo->ReleaseVarDesc(variableDescription);
+					throw;
+				}
+
+				// release variable description
+				pTypeInfo->ReleaseVarDesc(variableDescription);
+			}
+		}
+	}
+	catch (...)
+	{
+		// release type attributes
+		pTypeInfo->ReleaseTypeAttr(typeAttributes);
+		throw;
+	}
+
+	// release type attributes
+	pTypeInfo->ReleaseTypeAttr(typeAttributes);
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, HREFTYPE hRefType, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	// get referenced type info
+	ITypeInfoPtr referencedTypeInfo;
+	_com_util::CheckError(pTypeInfo->GetRefTypeInfo(hRefType, &referencedTypeInfo));
+
+	// get referenced type lib
+	ITypeLibPtr referencedTypeLibrary;
+	UINT referencedTypeInfoIndex;
+	_com_util::CheckError(referencedTypeInfo->GetContainingTypeLib(&referencedTypeLibrary, &referencedTypeInfoIndex));
+
+	// store dependency
+	if (referencedTypeLibrary != pTypeLib)
+		pOutput->insert(referencedTypeLibrary);
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, TYPEDESC& referencedTypeDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	switch (referencedTypeDescription.vt)
+	{
+	case VT_PTR:
+	{
+		// get dependencies of the pointer declaration
+		GetDependenciesHelper(pTypeLib, pTypeInfo, *referencedTypeDescription.lptdesc, pHistory, pOutput);
+		break;
+	}
+	case VT_CARRAY:
+	{
+		// get dependencies of the array declaration
+		GetDependenciesHelper(pTypeLib, pTypeInfo, *referencedTypeDescription.lpadesc, pHistory, pOutput);
+		break;
+	}
+	case VT_USERDEFINED:
+	{
+		// get dependencies of the UDT reference
+		GetDependenciesHelper(pTypeLib, pTypeInfo, referencedTypeDescription.hreftype, pHistory, pOutput);
+		break;
+	}
+	}
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, FUNCDESC& functionDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	// get dependencies of the function return value
+	GetDependenciesHelper(pTypeLib, pTypeInfo, functionDescription.elemdescFunc, pHistory, pOutput);
+
+	// iterate over parameters
+	auto parameterCount = functionDescription.cParams;
+	for (SHORT parameterIndex = 0; parameterIndex < parameterCount; ++parameterIndex)
+	{
+		// get parameter description
+		auto& parameterDescription = functionDescription.lprgelemdescParam[parameterIndex];
+
+		// get dependencies of the parameter declaration
+		GetDependenciesHelper(pTypeLib, pTypeInfo, parameterDescription, pHistory, pOutput);
+	}
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, VARDESC& variableDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	// get dependencies of the variable declaration
+	GetDependenciesHelper(pTypeLib, pTypeInfo, variableDescription.elemdescVar, pHistory, pOutput);
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, ARRAYDESC& arrayDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	// get dependencies of the array declaration
+	GetDependenciesHelper(pTypeLib, pTypeInfo, arrayDescription.tdescElem, pHistory, pOutput);
+}
+
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, ELEMDESC& elementDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput)
+{
+	// get dependencies of the array element declaration
+	GetDependenciesHelper(pTypeLib, pTypeInfo, elementDescription.tdesc, pHistory, pOutput);
+}

--- a/olewoo_interop/typelibdependencies.h
+++ b/olewoo_interop/typelibdependencies.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "Stdafx.h"
+#include <windows.h>
+#include <comdef.h>
+#include <unordered_set>
+
+// gets dependencies of a type library
+std::unordered_set<ITypeLibPtr> GetDependencies(ITypeLib* pTypeLib);
+
+// gathers dependencies of a type library
+void GetDependenciesHelper(ITypeLib* pTypeLib, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+// gathers dependencies of a type
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+// gathers dependencies of a reference
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, HREFTYPE hRefType, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+// gathers dependencies of a reference
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, TYPEDESC& referencedTypeDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+// gathers dependencies of a function declaration
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, FUNCDESC& functionDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+// gathers dependencies of a variable declaration
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, VARDESC& variableDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+// gathers dependencies of an array declaration
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, ARRAYDESC& arrayDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+// gathers dependencies of an array element declaration
+void GetDependenciesHelper(ITypeLib* pTypeLib, ITypeInfo* pTypeInfo, ELEMDESC& elementDescription, std::unordered_set<ITypeInfoPtr>* pHistory, std::unordered_set<ITypeLibPtr>* pOutput);
+
+namespace std
+{
+	// provides a function for hashing ITypeLibPtr instances by their raw address
+	template<> struct hash<ITypeLibPtr>
+	{
+		size_t operator()(ITypeLibPtr const& pTypeLib) const { return pTypeLib; }
+	};
+	// provides a function for hashing ITypeInfo instances by their raw address
+	template<> struct hash<ITypeInfoPtr>
+	{
+		size_t operator()(ITypeInfoPtr const& pTypeInfo) const { return pTypeInfo; }
+	};
+}

--- a/olewoo_interop/typestring.cpp
+++ b/olewoo_interop/typestring.cpp
@@ -13,12 +13,10 @@
 
 using namespace olewoo_interop;
 
-
-
 namespace olewoo_interop
 {
 
-void stringifyCustomType(HREFTYPE refType, ITypeInfo* pti, IDLFormatter_iop ^ ift, CustomTypeLibData ^ custLibData) 
+void stringifyCustomType(HREFTYPE refType, ITypeInfo* pti, IDLFormatter_iop ^ ift) 
 {
     CComPtr<ITypeInfo> pTypeInfo(pti);
     CComPtr<ITypeInfo> pCustTypeInfo;
@@ -35,30 +33,6 @@ void stringifyCustomType(HREFTYPE refType, ITypeInfo* pti, IDLFormatter_iop ^ if
 		ift->AddString("UnknownCustomType");
 		return;
 	}
-	ITypeLib* pCustTypeLib;
-	UINT uIndex;
-	hr = pCustTypeInfo->GetContainingTypeLib(&pCustTypeLib, &uIndex);
-	if (SUCCEEDED(hr))
-	{
-		CComBSTR bstrLib;
-		hr = pCustTypeLib->GetDocumentation(-1, &bstrLib, 0, 0, 0);
-		if (SUCCEEDED(hr))
-		{
-			LPTLIBATTR attr;
-			hr = pCustTypeLib->GetLibAttr(&attr);
-			if (SUCCEEDED(hr))
-			{
-				CustomTypeLibData^ data = gcnew CustomTypeLibData();
-				
-				data->LibName = msclr::interop::marshal_as<System::String^>(bstrLib.m_str);
-				data->LibGuid = MkSystemGuid(attr->guid);
-				data->MajorVersion = attr->wMajorVerNum;
-				data->MinorVersion = attr->wMinorVerNum;
-
-				pCustTypeLib->ReleaseTLibAttr(attr);
-			}
-		}
-	}
     char ansiType[MAX_PATH];
     WideCharToMultiByte(CP_ACP, 0, bstrType, bstrType.Length() + 1, 
         ansiType, MAX_PATH, 0, 0);
@@ -66,21 +40,21 @@ void stringifyCustomType(HREFTYPE refType, ITypeInfo* pti, IDLFormatter_iop ^ if
 	return;
 }
 
-void stringifyTypeDesc(TYPEDESC* typeDesc, ITypeInfo* pTypeInfo, IDLFormatter_iop ^ ift, CustomTypeLibData ^ custLibData) {
+void stringifyTypeDesc(TYPEDESC* typeDesc, ITypeInfo* pTypeInfo, IDLFormatter_iop ^ ift) {
     if(typeDesc->vt == VT_PTR) 
 	{
-        stringifyTypeDesc(typeDesc->lptdesc, pTypeInfo, ift, custLibData);
+        stringifyTypeDesc(typeDesc->lptdesc, pTypeInfo, ift);
 		ift->AddString("*");
 		return;
     }
     if(typeDesc->vt == VT_SAFEARRAY) {
         ift->AddString("SAFEARRAY(");
-        stringifyTypeDesc(typeDesc->lptdesc, pTypeInfo, ift, custLibData);
+        stringifyTypeDesc(typeDesc->lptdesc, pTypeInfo, ift);
 		ift->AddString(")");
 		return;
     }
     if(typeDesc->vt == VT_CARRAY) {
-        stringifyTypeDesc(&typeDesc->lpadesc->tdescElem, pTypeInfo, ift, custLibData);
+        stringifyTypeDesc(&typeDesc->lpadesc->tdescElem, pTypeInfo, ift);
         for(int dim(0); typeDesc->lpadesc->cDims; ++dim) 
 		{
 			std::stringstream oss;
@@ -92,7 +66,7 @@ void stringifyTypeDesc(TYPEDESC* typeDesc, ITypeInfo* pTypeInfo, IDLFormatter_io
 		return;
     }
     if(typeDesc->vt == VT_USERDEFINED) {
-        stringifyCustomType(typeDesc->hreftype, pTypeInfo, ift, custLibData);
+        stringifyCustomType(typeDesc->hreftype, pTypeInfo, ift);
         return;
     }
     


### PR DESCRIPTION
The PR attempts to make the IDL file generated by olewoo be compilable by MIDL by including the required `ImportLib` attributes and additionally include any `custom` attributes and `version` attribute to achieve closer parity with what is outputted by default oleview.exe.

The dependent libraries are pulled in using the code provided in this [Stack Overflow thread](https://stackoverflow.com/questions/45063037/find-dependent-type-libraries-in-typelib-file-through-code). It was also necessary to perform some registry lookup to supplement the data that is not given via the `ITypeLib` alone. Running the IDL through MIDL can give compilation error if the `ImportLib` is not on the path, so for that reason, olewoo will now supply the full path to the dependent libraries to aid the MIDL compilation. 

We also make use of `ITypeLib2` / `ITypeInfo2` to extract any custom data which should be included to ensure parity when generating type libraries from the provided IDL. 